### PR TITLE
Rework of collision shape logic & codebase cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DraggableSprite2D
-A simple Sprite2D which can be dragged with the mouse by clicking and holding with the left mouse button.
+A simple Sprite2D which can be dragged with the mouse by clicking and holding with a mouse button.
 
 ## Usage
 To use, just add a texture and ignore the warning in the editor. A collision shape is automatically generated on _ready.
@@ -7,6 +7,8 @@ To use, just add a texture and ignore the warning in the editor. A collision sha
 You can also use a custom collision shape by adding it as a child.
 
 All code is commented to explain the export values, but for reference:
+- **input_method**: The mouse button to listen for to grab the sprite.
 - **texture**: The Sprite2D texture. This updates live in the editor, as long as you swap editor tabs after changing it.
 - **return_to_origin**: Whether the sprite should return to it's starting point once released.
 - **grabbable**: Whether the sprite can be grabbed.
+- **origin**: The position to return to when released, if return_to_origin is true. Note that this is set to the sprite's starting position on `_ready`, so it should only be updated at runtime and not set in the editor.

--- a/addons/draggablesprite2d/plugin.cfg
+++ b/addons/draggablesprite2d/plugin.cfg
@@ -1,7 +1,7 @@
 [plugin]
 
 name="DraggableSprite2D"
-description="A simple Sprite2D which can be dragged with the mouse by clicking and holding with the left mouse button."
+description="A simple Sprite2D which can be dragged with the mouse by clicking and holding with a mouse button."
 author="BirDt"
 version="1.0"
 script="plugin.gd"

--- a/addons/draggablesprite2d/src/draggablesprite2d.gd
+++ b/addons/draggablesprite2d/src/draggablesprite2d.gd
@@ -89,8 +89,9 @@ func _process(delta) -> void:
 func has_custom_collider() -> bool:
 	var children = get_children()
 	for child in children:
-		if child is CollisionShape2D and child != default_collider:
-			return true
+		if child is CollisionShape2D or child is CollisionPolygon2D:
+			if child != default_collider:
+				return true
 	
 	return false
 
@@ -113,12 +114,12 @@ func _on_input_event(viewport, event, shape_idx) -> void:
 
 
 func _on_child_entered_tree(child) -> void:
-	if child is CollisionShape2D and child != default_collider:
+	if (child is CollisionShape2D or child is CollisionPolygon2D) and child != default_collider:
 		default_collider.visible = false
 		default_collider.disabled = true
 
 
 func _on_child_exiting_tree(child) -> void:
-	if child is CollisionShape2D and child != default_collider:
+	if (child is CollisionShape2D or child is CollisionPolygon2D) and child != default_collider:
 		default_collider.visible = true
 		default_collider.disabled = false

--- a/addons/draggablesprite2d/src/draggablesprite2d.gd
+++ b/addons/draggablesprite2d/src/draggablesprite2d.gd
@@ -55,7 +55,6 @@ func _ready() -> void:
 
 	add_child(sprite)
 
-	# Create the default collider
 	default_collider = CollisionShape2D.new()
 	default_collider.shape = RectangleShape2D.new()
 
@@ -63,8 +62,7 @@ func _ready() -> void:
 	
 	add_child(default_collider)
 	if has_custom_collider():
-		default_collider.visible = false
-		default_collider.disabled = true
+		toggle_default_collider(false)
 	
 	# Set the starting origin if necessary
 	if return_to_origin:
@@ -86,12 +84,18 @@ func _process(delta) -> void:
 ## Returns true if the sprite has a custom collider
 func has_custom_collider() -> bool:
 	var children = get_children()
+	children.erase(default_collider)
 	for child in children:
 		if child is CollisionShape2D or child is CollisionPolygon2D:
-			if child != default_collider:
-				return true
+			return true
 	
 	return false
+
+
+## Shortcut to toggle on or off the default collider functionality
+func toggle_default_collider(on: bool) -> void:
+	default_collider.visible = on
+	default_collider.disabled = not on
 
 
 ## Updates the default collider to match the size of the sprite
@@ -110,14 +114,11 @@ func _on_input_event(viewport, event, shape_idx) -> void:
 		# Helps a bit to make the dragging less choppy
 		grabbed_offset = position - get_global_mouse_position()
 
-
 func _on_child_entered_tree(child) -> void:
 	if (child is CollisionShape2D or child is CollisionPolygon2D) and child != default_collider:
-		default_collider.visible = false
-		default_collider.disabled = true
+		toggle_default_collider(false)
 
 
 func _on_child_exiting_tree(child) -> void:
 	if (child is CollisionShape2D or child is CollisionPolygon2D) and child != default_collider:
-		default_collider.visible = true
-		default_collider.disabled = false
+		toggle_default_collider(true)

--- a/addons/draggablesprite2d/src/draggablesprite2d.gd
+++ b/addons/draggablesprite2d/src/draggablesprite2d.gd
@@ -1,24 +1,12 @@
 @tool
-extends Area2D
+class_name DraggableSprite2D extends Area2D
 
-var sprite := Sprite2D.new()
-var collider : CollisionShape2D
 
-var is_grabbed := false :
-	set(x):
-		is_grabbed = x
-		## Emit signal if currently grabbed or not
-		if x:
-			grabbed.emit()
-		else:
-			released.emit()
-## Helps a bit to make the dragging less choppy
-var grabbed_offset := Vector2.ZERO
-## Store for the original position
-var origin := Vector2.ZERO
-
+## Emitted when the sprite is grabbed
 signal grabbed
+## Emitted when the sprite is released
 signal released
+
 
 ## Sprite texture
 ## This is a bit crap, since it can't be resized as nicely as a normal sprite2d
@@ -26,39 +14,60 @@ signal released
 	set(x):
 		texture = x
 		sprite.texture = texture
-		## Update the default collider with the shape and size of the sprite, if it exists
-		if collider and collider.shape:
-			collider.shape.size = Vector2(texture.get_width(), texture.get_height())
+		## Update the default_collider with the shape and size of the sprite, if it exists
+		update_default_collider()
 ## Whether or not the sprite should return to it's starting position when released
 @export var return_to_origin := false
 ## Whether or not it should be possible to grab the sprite
 @export var grabbable := true
 
+
+## The Sprite node that will be used to display the texture
+var sprite := Sprite2D.new()
+## The default collider. It is automatically created and updated to match the size of the sprite
+var default_collider : CollisionShape2D
+## Whether or not the sprite is currently grabbed
+var is_grabbed := false :
+	set(value):
+		is_grabbed = value
+		if is_grabbed:
+			grabbed.emit()
+		else:
+			released.emit()
+
+
+# Helps a bit to make the dragging less choppy
+var grabbed_offset := Vector2.ZERO
+# Store for the original position
+var origin := Vector2.ZERO
+# Mouse button pressed tracker, used to essentially replicate the behavior of 'is_action_just_released'
+var mb_pressed = false
+
+
 func _ready():
-	## Check if we need to instantiate a collider 
-	var children = get_children()
-	var needs_collider = true
-	for i in children:
-		## If a collision shape is a child, we don't need a collider
-		if i is CollisionShape2D or i is CollisionPolygon2D:
-			needs_collider = false
-	
-	## Otherwise, create a new collider from the size and shape of the sprite
-	if needs_collider:
-		collider = CollisionShape2D.new()
-		collider.shape = RectangleShape2D.new()
-		collider.shape.size = Vector2(texture.get_width() if texture else 0, texture.get_height() if texture else 0)
-		add_child(collider)
-	
-	## Set the starting origin if necessary
-	if return_to_origin:
-		origin = position
-	
-	add_child(sprite)
+	# Connect signals
+	child_entered_tree.connect(_on_child_entered_tree)
+	child_exiting_tree.connect(_on_child_exiting_tree)
 	input_event.connect(_on_input_event)
 
-## Mouse button pressed tracker, used to essentially replicate the behavior of 'is_action_just_released'
-var mb_pressed = false
+	# Add the sprite to the node
+	add_child(sprite)
+
+	# Create the default collider
+	default_collider = CollisionShape2D.new()
+	default_collider.shape = RectangleShape2D.new()
+
+	update_default_collider()
+	
+	add_child(default_collider)
+	# Hide the default_collider if there is a custom collider
+	if has_custom_collider():
+		default_collider.visible = false
+	
+	# Set the starting origin if necessary
+	if return_to_origin:
+		origin = position
+
 
 func _process(delta):
 	# If the left mouse button is down and the object is and can be grabbed, update it's position
@@ -71,9 +80,37 @@ func _process(delta):
 			position = origin
 		mb_pressed = false
 
+
+func has_custom_collider() -> bool:
+	var children = get_children()
+	for child in children:
+		if child is CollisionShape2D and child != default_collider:
+			return true
+	
+	return false
+
+
+func update_default_collider():
+		if default_collider and default_collider.shape:
+			if not texture:
+				default_collider.shape.size = Vector2(0, 0)
+				return
+			default_collider.shape.size = Vector2(texture.get_width(), texture.get_height())
+
+
 func _on_input_event(viewport, event, shape_idx):
 	## Detect when mouse button is clicked inside the area2d
 	if event is InputEventMouseButton and grabbable:
 		is_grabbed = event.is_pressed()
 		## Helps a bit to make the dragging less choppy
 		grabbed_offset = position - get_global_mouse_position()
+
+
+func _on_child_entered_tree(child):
+	if child is CollisionShape2D and child != default_collider:
+		default_collider.visible = false
+
+
+func _on_child_exiting_tree(child):
+	if child is CollisionShape2D and child != default_collider:
+		default_collider.visible = true

--- a/addons/draggablesprite2d/src/draggablesprite2d.gd
+++ b/addons/draggablesprite2d/src/draggablesprite2d.gd
@@ -66,6 +66,7 @@ func _ready() -> void:
 	# Hide the default_collider if there is a custom collider
 	if has_custom_collider():
 		default_collider.visible = false
+		default_collider.disabled = true
 	
 	# Set the starting origin if necessary
 	if return_to_origin:
@@ -114,8 +115,10 @@ func _on_input_event(viewport, event, shape_idx) -> void:
 func _on_child_entered_tree(child) -> void:
 	if child is CollisionShape2D and child != default_collider:
 		default_collider.visible = false
+		default_collider.disabled = true
 
 
 func _on_child_exiting_tree(child) -> void:
 	if child is CollisionShape2D and child != default_collider:
 		default_collider.visible = true
+		default_collider.disabled = false

--- a/addons/draggablesprite2d/src/draggablesprite2d.gd
+++ b/addons/draggablesprite2d/src/draggablesprite2d.gd
@@ -9,6 +9,8 @@ signal grabbed
 signal released
 
 
+## Whether or not it should be possible to grab the sprite
+@export var grabbable := true
 ## The input button that will be used to grab the sprite
 @export var input_method: MouseButton = MOUSE_BUTTON_LEFT
 ## The texture that will be displayed by the sprite. [br]
@@ -21,8 +23,8 @@ signal released
 		update_default_collider()
 ## Whether or not the sprite should return to it's starting position when released
 @export var return_to_origin := false
-## Whether or not it should be possible to grab the sprite
-@export var grabbable := true
+## The position the sprite will return to when released
+@export var origin := Vector2.ZERO
 
 
 ## The Sprite node that will be used to display the texture
@@ -41,8 +43,6 @@ var is_grabbed := false :
 
 # Helps a bit to make the dragging less choppy
 var grabbed_offset := Vector2.ZERO
-# Store for the original position
-var origin := Vector2.ZERO
 # Mouse button pressed tracker, used to essentially replicate the behavior of 'is_action_just_released'
 var mb_pressed = false
 

--- a/addons/draggablesprite2d/src/draggablesprite2d.gd
+++ b/addons/draggablesprite2d/src/draggablesprite2d.gd
@@ -53,7 +53,6 @@ func _ready() -> void:
 	child_exiting_tree.connect(_on_child_exiting_tree)
 	input_event.connect(_on_input_event)
 
-	# Add the sprite to the node
 	add_child(sprite)
 
 	# Create the default collider
@@ -63,7 +62,6 @@ func _ready() -> void:
 	update_default_collider()
 	
 	add_child(default_collider)
-	# Hide the default_collider if there is a custom collider
 	if has_custom_collider():
 		default_collider.visible = false
 		default_collider.disabled = true
@@ -74,7 +72,7 @@ func _ready() -> void:
 
 
 func _process(delta) -> void:
-	# If the left mouse button is down and the object is and can be grabbed, update it's position
+	# If the input_method is down and the object is and can be grabbed, update it's position
 	if Input.is_mouse_button_pressed(input_method) and is_grabbed and grabbable:
 		position = get_global_mouse_position() + grabbed_offset
 		mb_pressed = true

--- a/addons/draggablesprite2d/src/draggablesprite2d.gd
+++ b/addons/draggablesprite2d/src/draggablesprite2d.gd
@@ -1,5 +1,6 @@
 @tool
 class_name DraggableSprite2D extends Area2D
+## A draggable sprite that can be dragged using the left mouse button.
 
 
 ## Emitted when the sprite is grabbed
@@ -8,13 +9,15 @@ signal grabbed
 signal released
 
 
-## Sprite texture
-## This is a bit crap, since it can't be resized as nicely as a normal sprite2d
+## The input button that will be used to grab the sprite
+@export var input_method: MouseButton = MOUSE_BUTTON_LEFT
+## The texture that will be displayed by the sprite. [br]
+## Note: The texture can't be rezised as nicley as a Sprite2D.
 @export var texture : Texture2D : 
-	set(x):
-		texture = x
+	set(value):
+		texture = value
 		sprite.texture = texture
-		## Update the default_collider with the shape and size of the sprite, if it exists
+		# Update the default_collider with the shape and size of the sprite, if it exists
 		update_default_collider()
 ## Whether or not the sprite should return to it's starting position when released
 @export var return_to_origin := false
@@ -44,7 +47,7 @@ var origin := Vector2.ZERO
 var mb_pressed = false
 
 
-func _ready():
+func _ready() -> void:
 	# Connect signals
 	child_entered_tree.connect(_on_child_entered_tree)
 	child_exiting_tree.connect(_on_child_exiting_tree)
@@ -69,18 +72,19 @@ func _ready():
 		origin = position
 
 
-func _process(delta):
+func _process(delta) -> void:
 	# If the left mouse button is down and the object is and can be grabbed, update it's position
-	if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT) and is_grabbed and grabbable:
+	if Input.is_mouse_button_pressed(input_method) and is_grabbed and grabbable:
 		position = get_global_mouse_position() + grabbed_offset
 		mb_pressed = true
 	# Otherwise, if the mouse button was pressed on the previous frame but now isn't, the object is released
-	if not Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT) and mb_pressed:
+	if not Input.is_mouse_button_pressed(input_method) and mb_pressed:
 		if return_to_origin:
 			position = origin
 		mb_pressed = false
 
 
+## Returns true if the sprite has a custom collider
 func has_custom_collider() -> bool:
 	var children = get_children()
 	for child in children:
@@ -90,7 +94,8 @@ func has_custom_collider() -> bool:
 	return false
 
 
-func update_default_collider():
+## Updates the default collider to match the size of the sprite
+func update_default_collider() -> void:
 		if default_collider and default_collider.shape:
 			if not texture:
 				default_collider.shape.size = Vector2(0, 0)
@@ -98,19 +103,19 @@ func update_default_collider():
 			default_collider.shape.size = Vector2(texture.get_width(), texture.get_height())
 
 
-func _on_input_event(viewport, event, shape_idx):
-	## Detect when mouse button is clicked inside the area2d
+func _on_input_event(viewport, event, shape_idx) -> void:
+	# Detect when mouse button is clicked inside the area2d
 	if event is InputEventMouseButton and grabbable:
 		is_grabbed = event.is_pressed()
-		## Helps a bit to make the dragging less choppy
+		# Helps a bit to make the dragging less choppy
 		grabbed_offset = position - get_global_mouse_position()
 
 
-func _on_child_entered_tree(child):
+func _on_child_entered_tree(child) -> void:
 	if child is CollisionShape2D and child != default_collider:
 		default_collider.visible = false
 
 
-func _on_child_exiting_tree(child):
+func _on_child_exiting_tree(child) -> void:
 	if child is CollisionShape2D and child != default_collider:
 		default_collider.visible = true

--- a/example/debug_scene.tscn
+++ b/example/debug_scene.tscn
@@ -1,8 +1,11 @@
-[gd_scene load_steps=2 format=3 uid="uid://c0l4bs6wrgkpc"]
+[gd_scene load_steps=3 format=3 uid="uid://c0l4bs6wrgkpc"]
 
 [ext_resource type="Script" path="res://addons/draggablesprite2d/src/draggablesprite2d.gd" id="1_sop0s"]
+[ext_resource type="Texture2D" uid="uid://b8ghfqyuph10g" path="res://icon.svg" id="3_2q26k"]
 
 [node name="DebugScene" type="Node2D"]
 
 [node name="DraggableSprite2D" type="Area2D" parent="."]
+texture_filter = 3
 script = ExtResource("1_sop0s")
+texture = ExtResource("3_2q26k")

--- a/example/debug_scene.tscn
+++ b/example/debug_scene.tscn
@@ -1,12 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://bmtee0g6mus23"]
+[gd_scene load_steps=2 format=3 uid="uid://c0l4bs6wrgkpc"]
 
 [ext_resource type="Script" path="res://addons/draggablesprite2d/src/draggablesprite2d.gd" id="1_sop0s"]
-[ext_resource type="Texture2D" uid="uid://yocf0c1dpao1" path="res://addons/draggablesprite2d/src/icon.png" id="2_fhke8"]
 
 [node name="DebugScene" type="Node2D"]
-position = Vector2(30, 36)
 
 [node name="DraggableSprite2D" type="Area2D" parent="."]
-position = Vector2(16, 5)
 script = ExtResource("1_sop0s")
-texture = ExtResource("2_fhke8")


### PR DESCRIPTION
Hey! Thanks for making this plugin. I forked the repo and fixed some issues with the collision shapes, added some features and cleaned up the code!

## Features
#### Major
- Automatically switch between the default and the custom collision shape
- Added `input_method` export variable to select a mouse button. (It would be even cleaner to use Input Actions here)
####Minor
- Cleaned up codebase
- Reordered layout of the code according to the GDScript style guide
- Cleaned up and added comments

One thing to consider from the [GodotDocs](https://docs.godotengine.org/en/stable/tutorials/plugins/editor/making_plugins.html#a-custom-node):

> Nodes added via an EditorPlugin are "CustomType" nodes. While they work with any scripting language, they have fewer features than [the Script Class system](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html#doc-gdscript-basics-class-name). If you are writing GDScript or NativeScript, we recommend using Script Classes instead.

I already added the node as a script class!

Please test this PR in case I missed something ^^